### PR TITLE
Add bootloader only to CI release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,4 @@ jobs:
     with:
       builder_image: 'bitcraze/builder'
       build_script: './tools/build/build-update-binary'
-      artifacts: |
-        _build/sd130_bootloader.bin
-        _build/bootloader_only_for_swd.bin
+      artifacts: '_build/sd130_bootloader.bin, _build/bootloader_only_for_swd.bin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,4 +11,4 @@ jobs:
     with:
       builder_image: 'bitcraze/builder'
       build_script: './tools/build/build-update-binary'
-      artifacts: '_build/sd130_bootloader.bin, _build/bootloader_only_for_swd.bin'
+      artifacts: '_build/sd130_bootloader.bin _build/bootloader_only_for_swd.bin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,4 +11,6 @@ jobs:
     with:
       builder_image: 'bitcraze/builder'
       build_script: './tools/build/build-update-binary'
-      artifacts: '_build/sd130_bootloader.bin'
+      artifacts: |
+        _build/sd130_bootloader.bin
+        _build/bootloader_only_for_swd.bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,4 +11,4 @@ jobs:
     with:
       builder_image: 'bitcraze/builder'
       build_script: './tools/build/build-update-binary'
-      artifacts: '_build/sd130_bootloader.bin _build/bootloader_only_for_swd.bin'
+      artifacts: '_build/sd130_bootloader.bin _build/nrf_bootloader.bin'

--- a/tools/generate_update_binary.py
+++ b/tools/generate_update_binary.py
@@ -5,9 +5,9 @@ from zlib import crc32
 from os import system
 
 system("arm-none-eabi-objcopy -I ihex -O binary vendor/nrf5sdk/components/softdevice/s130/hex/s130_nrf51_2.0.1_softdevice.hex _build/s130.bin")
-system("mv _build/nrf51422_xxaa.bin _build/bootloader_only_for_swd.bin")
+system("mv _build/nrf51422_xxaa.bin _build/nrf_bootloader.bin")
 
-bl = open('_build/bootloader_only_for_swd.bin', 'rb').read()
+bl = open('_build/nrf_bootloader.bin', 'rb').read()
 sd = open('_build/s130.bin', 'rb').read()
 
 # Strip the 4K MBR from the begining of the softdevice

--- a/tools/generate_update_binary.py
+++ b/tools/generate_update_binary.py
@@ -5,8 +5,9 @@ from zlib import crc32
 from os import system
 
 system("arm-none-eabi-objcopy -I ihex -O binary vendor/nrf5sdk/components/softdevice/s130/hex/s130_nrf51_2.0.1_softdevice.hex _build/s130.bin")
+system("mv _build/nrf51422_xxaa.bin _build/bootloader_only_for_swd.bin")
 
-bl = open('_build/nrf51422_xxaa.bin', 'rb').read()
+bl = open('_build/bootloader_only_for_swd.bin', 'rb').read()
 sd = open('_build/s130.bin', 'rb').read()
 
 # Strip the 4K MBR from the begining of the softdevice


### PR DESCRIPTION
We need to have a bootloader only binary available for use by SWD.